### PR TITLE
Mariadb support

### DIFF
--- a/src/PHPFUI/MySQLSlowQuery/Entry.php
+++ b/src/PHPFUI/MySQLSlowQuery/Entry.php
@@ -96,6 +96,19 @@ class Entry extends \PHPFUI\MySQLSlowQuery\BaseObject
 			$line = \str_replace(' [', '[', $line);
 			}
 
+		if (\str_starts_with($line, '# Time') && ($this->parameters['parse_mode'] ?? '') == 'mariadb')
+			{
+			// A "Time" value is so for the only one with a space inside the value.
+			// Unify with mysql log format: replace space with T, replace second space
+			// with leading zero, expand YYMMDD value and add microseconds.
+			$parts = \explode(' ', \substr($line, 8), 2);
+			if ($parts[1][0] === ' ')
+				{
+				$parts[1][0] = '0';
+				}
+			$line = \preg_replace('/(\d{2})(\d{2})(\d{2})/', "# Time: 20\\1-\\2-\\3T{$parts[1]}.000000Z", $parts[0]);
+			}
+
 		$parts = \explode(' ', \substr($line, 2));
 
 		while (\count($parts))

--- a/src/PHPFUI/MySQLSlowQuery/Entry.php
+++ b/src/PHPFUI/MySQLSlowQuery/Entry.php
@@ -17,9 +17,15 @@ namespace PHPFUI\MySQLSlowQuery;
  */
 class Entry extends \PHPFUI\MySQLSlowQuery\BaseObject
 	{
+	private array $parameters = [];
+
 	// @phpstan-ignore-next-line
 	public function __construct(array $parameters = [])
 		{
+		$this->parameters = $parameters;
+
+		// Ignore $parameters; restrict available fields based on known log files
+		// produced by specific server versions.
 		$this->fields = [
 			'Time' => '',
 			'User' => '',
@@ -30,8 +36,35 @@ class Entry extends \PHPFUI\MySQLSlowQuery\BaseObject
 			'Rows_sent' => 0,
 			'Rows_examined' => 0,
 			'Query' => [],
+			// Session is not present in logfile. It starts at 0 and is pointed to
+			// $session (not object but index in array of sessions) later.
 			'Session' => 0,
 		];
+		if (($this->parameters['parse_mode'] ?? '') == 'mariadb')
+			{
+			unset($this->fields['Id']);
+			$this->fields += [
+				'Thread_id' => 0,
+				'Schema' => '',
+				'QC_hit' => '',
+				'Rows_affected' => 0,
+				'Bytes_sent' => 0,
+				// Apparently dependent on configuration - not present in all logfiles:
+				'Tmp_tables' => 0,
+				'Tmp_disk_tables' => 0,
+				'Tmp_table_sizes' => 0,
+				'Full_scan' => '',
+				'Full_join' => '',
+				'Tmp_table' => '',
+				'Tmp_table_on_disk' => '',
+				'Filesort' => '',
+				'Filesort_on_disk' => '',
+				'Merge_passes' => 0,
+				'Priority_queue' => '',
+				// 'explain: ' is not just one property; needs special parsing.
+				'explain' => '',
+			];
+			}
 		}
 
 	/**

--- a/src/PHPFUI/MySQLSlowQuery/Parser.php
+++ b/src/PHPFUI/MySQLSlowQuery/Parser.php
@@ -176,7 +176,7 @@ class Parser
 				}
 			elseif ('#' === $line[0])	// start of log entry
 				{
-				$entry = new \PHPFUI\MySQLSlowQuery\Entry();
+				$entry = new \PHPFUI\MySQLSlowQuery\Entry(['parse_mode' => $parseMode]);
 				$query = [];
 				if ($parseMode === '')
 					{

--- a/src/PHPFUI/MySQLSlowQuery/Parser.php
+++ b/src/PHPFUI/MySQLSlowQuery/Parser.php
@@ -152,7 +152,7 @@ class Parser
 				// eat the next line
 				$this->getNextLine();
 				// create a new session
-				$this->sessions[] = new \PHPFUI\MySQLSlowQuery\Session($currentSession);
+				$this->sessions[] = new \PHPFUI\MySQLSlowQuery\Session($currentSession, $parseMode);
 				$currentSession = [];
 				$this->inSession = false;
 

--- a/src/PHPFUI/MySQLSlowQuery/Parser.php
+++ b/src/PHPFUI/MySQLSlowQuery/Parser.php
@@ -155,6 +155,19 @@ class Parser
 				$this->sessions[] = new \PHPFUI\MySQLSlowQuery\Session($currentSession);
 				$currentSession = [];
 				$this->inSession = false;
+
+				// The next line is expected to be a comment connected to the first
+				// query in this session. In non backward compatible mode, check this:
+				// if it's not a comment line, this is assumed to be the start of the
+				// next session header (i.e. there are zero queries in this session).
+				if ($parseMode === 'mariadb' && \strlen($line = $this->getNextLine()) > 0)
+					{
+					if ('#' !== $line[0])
+						{
+						$this->inSession = true;
+						}
+					$this->pushLine($line);
+					}
 				}
 			elseif ($this->inSession)	// in session, grab line
 				{

--- a/src/PHPFUI/MySQLSlowQuery/Session.php
+++ b/src/PHPFUI/MySQLSlowQuery/Session.php
@@ -4,25 +4,35 @@ namespace PHPFUI\MySQLSlowQuery;
 
 /**
  * @property string $Server
+ * @property string $Version
  * @property string $Port
  * @property string $Transport
  */
 class Session extends \PHPFUI\MySQLSlowQuery\BaseObject
 	{
 	/** @param array<int, string> $sessionData */
-	public function __construct(array $sessionData = [])
+	public function __construct(array $sessionData = [], $parseMode = '')
 		{
 		$this->fields = [
+			// Almost the full first line, i.e. executable and version.
 			'Server' => '',
+			// The version number also found in the 'Server' line, without "Version: "
+			// e.g. "8.0.21 (MySQL Community Server - GPL)"
+			//      "10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)"
+			'Version' => '',
+			// Not only port number; includes "TCP port: "
 			'Port' => '',
+			// e.g. "Named pipe: ..." (mysql) or "Unix socket: ..." (mariadb)
 			'Transport' => '',
 		];
 
 		$this->Server = \trim(\str_replace('. started with:', '', $sessionData[0] ?? 'unknown'));
+		$this->Version = \substr(\strstr($this->Server, 'Version: ') ?: '', 9);
 
-		if (\strpos($sessionData[1] ?? '', ', '))
+		$delimiter = $parseMode == 'mariadb' ? '  ' : ', ';
+		if (\strpos($sessionData[1] ?? '', $delimiter))
 			{
-			[$this->Port, $this->Transport] = \explode(', ', \trim($sessionData[1]));
+			[$this->Port, $this->Transport] = \explode($delimiter, \trim($sessionData[1]));
 			}
 		}
 	}

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -20,6 +20,16 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertCount(0, $parser->getEntries());
 		}
 
+		public function testBadFile2() : void
+	{
+		$parser = new \PHPFUI\MySQLSlowQuery\Parser(__DIR__ . '/logs/ignoredData.log');
+		$this->assertCount(1, $parser->getSessions());
+		$entries = $parser->getEntries();
+		$this->assertCount(2, $entries);
+		// See comments in logfile on why the query is not found.
+		$this->assertEmpty($entries[0]->Query);
+	}
+
 	public function testDoubleSession() : void
 		{
 		$parser = new \PHPFUI\MySQLSlowQuery\Parser(__DIR__ . '/logs/doubleSession.log');

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -20,16 +20,6 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertCount(0, $parser->getEntries());
 		}
 
-		public function testBadFile2() : void
-	{
-		$parser = new \PHPFUI\MySQLSlowQuery\Parser(__DIR__ . '/logs/ignoredData.log');
-		$this->assertCount(1, $parser->getSessions());
-		$entries = $parser->getEntries();
-		$this->assertCount(2, $entries);
-		// See comments in logfile on why the query is not found.
-		$this->assertEmpty($entries[0]->Query);
-	}
-
 	public function testDoubleSession() : void
 		{
 		$parser = new \PHPFUI\MySQLSlowQuery\Parser(__DIR__ . '/logs/doubleSession.log');
@@ -129,5 +119,21 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals('0.000375', $entry->Lock_time);
 		$this->assertEquals('0', $entry->Rows_sent);
 		$this->assertEquals('6', $entry->Rows_examined);
+		}
+
+	public function testMysqlVsMariadb() : void
+		{
+		$parser = new \PHPFUI\MySQLSlowQuery\Parser(__DIR__ . '/logs/ignoredData.log');
+		$sessions = $parser->getSessions();
+		$this->assertCount(2, $sessions);
+		$entries = $parser->getEntries();
+		// See comments in logfile on why the query is not found in the first entry
+		// (backward compatible style parsing). The comments are swept up into a
+		// fourth fake entry.
+		$this->assertCount(4, $entries);
+		$this->assertEmpty($entries[0]->Query);
+		$this->assertNotEmpty($entries[2]->Query);
+		// Mariadb style parsing also processes comments above "Time: "
+		$this->assertEquals('0.001519', $entries[2]->Query_time);
 		}
 	}

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -135,6 +135,8 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals('Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock', $sessions[4]->Server);
 		$this->assertEquals('Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock', $sessions[5]->Server);
 		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[6]->Server);
+		// It took until the previous session for mariadb to kick in, but going
+		// forward "sessions without query entries" are parsed OK.
 		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[7]->Server);
 		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[8]->Server);
 		$this->assertEquals('Unix socket: /run/mysqld/mysqld.sock', $sessions[8]->Transport);
@@ -148,9 +150,11 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertNotEmpty($entries[3]->Query);
 		$this->assertNotEmpty($entries[4]->Query);
 		// Done on Mariadb only:
-		// comments above "Time: "
+		// Comments above "Time: " are parsed:
 		$this->assertEquals('0.001519', $entries[4]->Query_time);
-		// extra properties
+		// Extra properties:
 		$this->assertEquals('1', $entries[4]->Rows_affected);
+		// "Time: 220907 18:55:33" is reformatted to be the same as mysql:
+		$this->assertEquals('2022-09-07T18:55:33.000000Z', $entries[4]->Time);
 		}
 	}

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -137,6 +137,7 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[6]->Server);
 		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[7]->Server);
 		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[8]->Server);
+		$this->assertEquals('Unix socket: /run/mysqld/mysqld.sock', $sessions[8]->Transport);
 		// See comments in logfile for why the query is not found in the first/third
 		// entry (backward compatible style parsing). The comments are swept up into
 		// a sixth fake entry.

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -142,13 +142,14 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals('Unix socket: /run/mysqld/mysqld.sock', $sessions[8]->Transport);
 		// See comments in logfile for why the query is not found in the first/third
 		// entry (backward compatible style parsing). The comments are swept up into
-		// a sixth fake entry.
-		$this->assertCount(6, $entries);
+		// a seventh fake entry.
+		$this->assertCount(7, $entries);
 		$this->assertEmpty($entries[0]->Query);
 		$this->assertNotEmpty($entries[1]->Query);
 		$this->assertEmpty($entries[2]->Query);
 		$this->assertNotEmpty($entries[3]->Query);
 		$this->assertNotEmpty($entries[4]->Query);
+		$this->assertNotEmpty($entries[5]->Query);
 		// Done on Mariadb only:
 		// Comments above "Time: " are parsed:
 		$this->assertEquals('0.001519', $entries[4]->Query_time);
@@ -156,5 +157,7 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals('1', $entries[4]->Rows_affected);
 		// "Time: 220907 18:55:33" is reformatted to be the same as mysql:
 		$this->assertEquals('2022-09-07T18:55:33.000000Z', $entries[4]->Time);
+		// Time is copied into next entry if not present in comment header:
+		$this->assertEquals('2022-09-07T18:55:33.000000Z', $entries[5]->Time);
 		}
 	}

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -125,15 +125,28 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		{
 		$parser = new \PHPFUI\MySQLSlowQuery\Parser(__DIR__ . '/logs/ignoredData.log');
 		$sessions = $parser->getSessions();
-		$this->assertCount(2, $sessions);
 		$entries = $parser->getEntries();
-		// See comments in logfile on why the query is not found in the first entry
-		// (backward compatible style parsing). The comments are swept up into a
-		// fourth fake entry.
-		$this->assertCount(4, $entries);
+		$this->assertCount(9, $sessions);
+		// See comments in logfile for why session 3-6 are buggy and 7-9 are not.
+		$this->assertEquals('c:\wamp64\bin\mysql\mysql8.0.21\bin\mysqld.exe, Version: 8.0.21 (MySQL Community Server - GPL)', $sessions[0]->Server);
+		$this->assertEquals('c:\wamp64\bin\mysql\mysql8.0.21\bin\mysqld.exe, Version: 8.0.21 (MySQL Community Server - GPL)', $sessions[1]->Server);
+		$this->assertEquals('Tcp Port: 3306, Named Pipe: /tmp/mysql.sock', $sessions[2]->Server);
+		$this->assertEquals('Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock', $sessions[3]->Server);
+		$this->assertEquals('Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock', $sessions[4]->Server);
+		$this->assertEquals('Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock', $sessions[5]->Server);
+		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[6]->Server);
+		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[7]->Server);
+		$this->assertEquals('mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution)', $sessions[8]->Server);
+		// See comments in logfile for why the query is not found in the first/third
+		// entry (backward compatible style parsing). The comments are swept up into
+		// a sixth fake entry.
+		$this->assertCount(6, $entries);
 		$this->assertEmpty($entries[0]->Query);
-		$this->assertNotEmpty($entries[2]->Query);
+		$this->assertNotEmpty($entries[1]->Query);
+		$this->assertEmpty($entries[2]->Query);
+		$this->assertNotEmpty($entries[3]->Query);
+		$this->assertNotEmpty($entries[4]->Query);
 		// Mariadb style parsing also processes comments above "Time: "
-		$this->assertEquals('0.001519', $entries[2]->Query_time);
+		$this->assertEquals('0.001519', $entries[4]->Query_time);
 		}
 	}

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -147,7 +147,10 @@ class UnitTest extends \PHPUnit\Framework\TestCase
 		$this->assertEmpty($entries[2]->Query);
 		$this->assertNotEmpty($entries[3]->Query);
 		$this->assertNotEmpty($entries[4]->Query);
-		// Mariadb style parsing also processes comments above "Time: "
+		// Done on Mariadb only:
+		// comments above "Time: "
 		$this->assertEquals('0.001519', $entries[4]->Query_time);
+		// extra properties
+		$this->assertEquals('1', $entries[4]->Rows_affected);
 		}
 	}

--- a/tests/logs/ignoredData.log
+++ b/tests/logs/ignoredData.log
@@ -16,6 +16,33 @@ SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesti
 use avance;
 SET timestamp=1606936123;
 SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesting_event_id = 17;
+c:\wamp64\bin\mysql\mysql8.0.21\bin\mysqld.exe, Version: 8.0.21 (MySQL Community Server - GPL). started with:
+Tcp Port: 3306, Named Pipe: /tmp/mysql.sock
+Time                 Id Command    Argument
+c:\wamp64\bin\mysql\mysql8.0.21\bin\mysqld.exe, Version: 8.0.21 (MySQL Community Server - GPL). started with:
+Tcp Port: 3306, Named Pipe: /tmp/mysql.sock
+Time                 Id Command    Argument
+mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
+Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
+Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# Time: 220907 18:55:31
+# UnknownProperty: ignored_by_default
+# User@Host: root[root] @ localhost [::1]  Id:     8
+# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
+use avance;
+SELECT 'this session is still being processed as non-mariadb style, so this query is still not recorded (because extra comment line)';
+mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
+Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# FirstLine: ignored_by_default
+# Time: 220907 18:55:31
+# User@Host: root[root] @ localhost [::1]  Id:     8
+# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
+use avance;
+SELECT 'this session is STILL being processed as non-mariadb style, but the query is recorded (because no extra comment line)';
 mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
 Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
 Time                 Id Command    Argument
@@ -24,8 +51,13 @@ Time                 Id Command    Argument
 # UnknownProperty: ignored_by_default
 # User@Host: root[root] @ localhost [::1]  Id:     8
 use avance;
-SET timestamp=1606936123;
-SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesting_event_id = 17;
+SELECT 'THIS session is finally recognized as mariadb (so the query is recorded), because the PREVIOUS query block was a valid backward compatible one, with only two comment lines below the "Time: " line';
+mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
+Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
+Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
+Time                 Id Command    Argument
 #
 # Explanation of above properties vs. (default) parser logic:
 # 1. The UnknownProperty property is ignored because Entry::setFromLine()
@@ -35,6 +67,9 @@ SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesti
 # 3. The query part in the first entry is ignored because Parser::parse() parses
 #    exactly three commented lines; any further comment line will revert to
 #    point 1 (and therefore ignore the query plus any other unknown lines).
+# 4. If a session header is immediately followed by another session header
+#    (i.e. it has zero queries logged), the new session object does not get
+#    the first line and its Server property says "TCP port: ..." -> bug.
 #
 # For mariadb,
 # - 1 is unchanged.
@@ -42,3 +77,5 @@ SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesti
 #   previous logged query is executed at the same time.)
 # - 3 is fixed: the query is not ignored (because we don't process exactly three
 #   comment lines)
+# - 4 is fixed, but only after any queries are processed. The last three in the
+#   above block of four adjacent session headers are all 'buggy'.

--- a/tests/logs/ignoredData.log
+++ b/tests/logs/ignoredData.log
@@ -61,6 +61,10 @@ Time                 Id Command    Argument
 #
 use avance;
 SELECT 'THIS session is finally recognized as mariadb (so the query is recorded), because the PREVIOUS query block was a valid backward compatible one, with only two comment lines below the "Time: " line';
+# User@Host: root[root] @ localhost [::1]  Id:     8
+# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
+# Rows_affected: 1  Bytes_sent: 5709
+SELECT 'Header without time spec';
 mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
 Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
 Time                 Id Command    Argument

--- a/tests/logs/ignoredData.log
+++ b/tests/logs/ignoredData.log
@@ -16,6 +16,16 @@ SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesti
 use avance;
 SET timestamp=1606936123;
 SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesting_event_id = 17;
+mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
+Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
+# Time: 220907 18:55:31
+# UnknownProperty: ignored_by_default
+# User@Host: root[root] @ localhost [::1]  Id:     8
+use avance;
+SET timestamp=1606936123;
+SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesting_event_id = 17;
 #
 # Explanation of above properties vs. (default) parser logic:
 # 1. The UnknownProperty property is ignored because Entry::setFromLine()
@@ -25,3 +35,10 @@ SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesti
 # 3. The query part in the first entry is ignored because Parser::parse() parses
 #    exactly three commented lines; any further comment line will revert to
 #    point 1 (and therefore ignore the query plus any other unknown lines).
+#
+# For mariadb,
+# - 1 is unchanged.
+# - 2 is fixed. (It has to be, because "# Time: " is not always included if the
+#   previous logged query is executed at the same time.)
+# - 3 is fixed: the query is not ignored (because we don't process exactly three
+#   comment lines)

--- a/tests/logs/ignoredData.log
+++ b/tests/logs/ignoredData.log
@@ -47,7 +47,7 @@ mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary dis
 Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
 Time                 Id Command    Argument
 # Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
-# Time: 220907 18:55:31
+# Time: 220907 18:55:33
 # UnknownProperty: ignored_by_default
 # User@Host: root[root] @ localhost [::1]  Id:     8
 # Rows_affected: 1  Bytes_sent: 5709

--- a/tests/logs/ignoredData.log
+++ b/tests/logs/ignoredData.log
@@ -1,0 +1,27 @@
+c:\wamp64\bin\mysql\mysql8.0.21\bin\mysqld.exe, Version: 8.0.21 (MySQL Community Server - GPL). started with:
+Tcp Port: 3306, Named Pipe: /tmp/mysql.sock
+Time                 Id Command    Argument
+# FirstLine: ignored_by_default
+# Time: 2020-12-02T19:08:43.462468Z
+# UnknownProperty: ignored_by_default
+# User@Host: root[root] @ localhost [::1]  Id:     8
+# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
+use avance;
+SET timestamp=1606936123;
+SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesting_event_id = 17;
+# FirstLine: ignored_by_default
+# Time: 2020-12-02T19:08:43.462468Z
+# User@Host: root[root] @ localhost [::1]  Id:     8
+# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
+use avance;
+SET timestamp=1606936123;
+SELECT st.* FROM performance_schema.events_stages_history_long st WHERE st.nesting_event_id = 17;
+#
+# Explanation of above properties vs. (default) parser logic:
+# 1. The UnknownProperty property is ignored because Entry::setFromLine()
+#    throws away any properties that are not explicitly defined.
+# 2. The FirstLine property is ignored because Parser::parse() throws away any
+#    line until "# Time: " is encountered.
+# 3. The query part in the first entry is ignored because Parser::parse() parses
+#    exactly three commented lines; any further comment line will revert to
+#    point 1 (and therefore ignore the query plus any other unknown lines).

--- a/tests/logs/ignoredData.log
+++ b/tests/logs/ignoredData.log
@@ -50,6 +50,15 @@ Time                 Id Command    Argument
 # Time: 220907 18:55:31
 # UnknownProperty: ignored_by_default
 # User@Host: root[root] @ localhost [::1]  Id:     8
+# Rows_affected: 1  Bytes_sent: 5709
+#
+# explain: id   select_type     table   type    possible_keys   key     key_len ref     rows    r_rows  filtered        r_filtered      Extra
+# explain: 1    SIMPLE  revision        ref     rev_page_timestamp      rev_page_timestamp      4       const   26      27.00   100.00  100.00  Using temporary; Using filesort
+# explain: 1    SIMPLE  comment_rev_comment     index   PRIMARY comment_hash    4       NULL    1       4456.00 100.00  100.00  Using index; Using join buffer (flat, BNL join)
+# explain: 1    SIMPLE  actor_rev_user  index   PRIMARY actor_name      257     NULL    1       50.00   100.00  100.00  Using index; Using join buffer (incremental, BNL join)
+# explain: 1    SIMPLE  temp_rev_comment        eq_ref  PRIMARY,revcomment_rev  PRIMARY 12      newgon_wiki.revision.rev_id,newgon_wiki.comment_rev_comment.comment_id  1       0.00    100.00  100.00      Using index
+# explain: 1    SIMPLE  temp_rev_user   eq_ref  PRIMARY,revactor_rev,actor_timestamp    PRIMARY 12      newgon_wiki.revision.rev_id,newgon_wiki.actor_rev_user.actor_id 1       0.02    100.00  100.00      Using index
+#
 use avance;
 SELECT 'THIS session is finally recognized as mariadb (so the query is recorded), because the PREVIOUS query block was a valid backward compatible one, with only two comment lines below the "Time: " line';
 mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:


### PR DESCRIPTION
I like this particular project because it parses lines one by one (instead of doing multi-line regexps) so its time/memory consumption does not go overboard.

However, it does not properly parse logfiles generated by MariaDB.

This PR does not solve all of the issues (see https://github.com/rmuit/MySQLSlowQueryParser/tree/mariadb for more changes); it concentrates on fixing the parse loop in Parser.

Issues I found with the following representative example:
```
mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
Time                 Id Command    Argument
mysqld, Version: 10.7.1-MariaDB-1:10.7.1+maria~focal-log (mariadb.org binary distribution). started with:
Tcp port: 0  Unix socket: /run/mysqld/mysqld.sock
Time                 Id Command    Argument
# Time: 220907 18:55:31
# User@Host: root[root] @ localhost [::1]  Id:     8
# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
# Rows_affected: 0  Bytes_sent: 11
SELECT SOMETHING;
# User@Host: root[root] @ localhost [::1]  Id:     8
# Query_time: 0.001519  Lock_time: 0.000214 Rows_sent: 0  Rows_examined: 0
# Rows_affected: 0  Bytes_sent: 11
SELECT SOMETHING;
```
1. If two 'session headers' immediately follow each other, the second session object does not get the first 'Server' line passed in. So its `$session->Server property` is "Tcp port: ...." and its `Port` / `Transport` properties are empty.
2. Any comments up until "`# Time: `" are discarded. Since MariaDB sometimes does not always include a "`# Time: `" line (! if the query happens in the same second as the previous one?), whole entries are discarded.
3. After the "`# Time: `" comment line, exactly two extra comment lines are parsed. If the next line is still a comment (which happens with MariaDB because it has at least one extra line for "`Rows_affected: ...`", it's seen as a new entry, so
   * The original entry does not get its query included
   * Its comment lines and query are completely discarded because see point 2.

It looks to me like all of this is just an effect of quick coding and lack of tests for the edge cases. (And likely point 1 also exists for mysql log files?) However... I can't be 100% sure that there aren't existing logfiles with e.g. extra comment lines or garbage that you actually _want to_ be ignored. So I
* introduced an extra local variable for 'parse mode' which can be "" or "mariadb" based on the contents of the first server line
* made sure to keep the current behavior unchanged, _unless_ parsing in "mariadb" mode - then points 1-3 are fixed 
...to make it easier to consider this PR for inclusion.

However, if you just want these points to be fixed always... I can do that, and include tests for them. With or without simplifying other code in the big parsing 'while' loop, too.

(Regardless whether we do this / need the 'parse mode' in this loop: for proper mariadb property parsing, i.e. the code already in my repository... we'll need a 'parse mode' to change behavior inside the Session and Entry classes.)